### PR TITLE
Feature/travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ language: c
 
 branches:
   only:
-    - /^([0-9.]+)(-\w+)?$/
+    #- /^([0-9.]+)(-\w+)?$/
+    - /.*/
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: required
+dist: trusty
+group: deprecated-2017Q4
+
+language: c
+
+branches:
+  only:
+    - /^([0-9.]+)(-\w+)?$/
+
+services:
+  - docker
+
+script:
+  - make lint
+  - make build test
+  - make tag push

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ language: c
 
 branches:
   only:
-    #- /^([0-9.]+)(-\w+)?$/
-    - /.*/
+    - /^([0-9.]+)(-\w+)?$/
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.6-alpine
 
-ARG BUILD_DATE
-
 # Install new packages
 RUN apk add --update build-base python-dev py-pip jpeg-dev zlib-dev libffi-dev openssl-dev git openssh-client sshpass
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ WORKDIR /ansible
 VOLUME [ "/ansible" ]
 
 # Install ansible
-ARG ANSIBLE_VERSION=2.7.4
+ARG ANSIBLE_VERSION=2.5 
 
 RUN pip install ansible==$ANSIBLE_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM python:3.6-alpine
 
 ARG BUILD_DATE
 
-LABEL maintainer="Intelygenz"
-LABEL org.label-schema.build-date=$BUILD_DATE
-
 # Install new packages
 RUN apk add --update build-base python-dev py-pip jpeg-dev zlib-dev libffi-dev openssl-dev git openssh-client sshpass
 
@@ -21,5 +18,6 @@ WORKDIR /ansible
 VOLUME [ "/ansible" ]
 
 # Install ansible
-ARG ANSIBLE_VERSION
+ARG ANSIBLE_VERSION=2.7.4
+
 RUN pip install ansible==$ANSIBLE_VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+OWNER=alpiquero
+IMAGE_NAME=ansible
+IMAGE_VERSION=$(TRAVIS_TAG)
+QNAME=$(OWNER)/$(IMAGE_NAME)
+
+TEST_TAG=$(QNAME):test
+BUILD_TAG=$(QNAME):$(IMAGE_VERSION)
+LATEST_TAG=$(QNAME):latest
+
+build:
+	docker build \
+		--build-arg ANSIBLE_VERSION=$(IMAGE_VERSION) \
+		-t $(TEST_TAG) .
+
+test:
+	docker run --rm $(TEST_TAG) ansible --version | grep $(IMAGE_VERSION)
+
+lint:
+	docker run -it --rm -v "$(PWD)/Dockerfile:/Dockerfile:ro" redcoolbeans/dockerlint
+
+tag:
+	docker tag $(TEST_TAG) $(BUILD_TAG)
+	docker tag $(TEST_TAG) $(LATEST_TAG)
+
+login:
+	@docker login -u "$(DOCKER_USER)" -p "$(DOCKER_PASS)"
+
+push: login
+	docker push $(BUILD_TAG)
+	docker push $(LATEST_TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OWNER=alpiquero
+OWNER=intelygenz
 IMAGE_NAME=ansible
 IMAGE_VERSION=$(TRAVIS_TAG)
 QNAME=$(OWNER)/$(IMAGE_NAME)


### PR DESCRIPTION
Complete CI/CD system created using TravisCI.

New Images will be published in https://hub.docker.com when a new tag is pushed. **Tag names must coincide with Ansible python3 supported versions.** These versions are **>=2.5**.

From Ansible v2.5, available versions from pip are:

```
2.5.0, 2.5.1, 2.5.2, 2.5.3, 2.5.4, 2.5.5, 2.5.6, 2.5.7, 2.5.8, 2.5.9, 2.5.10, 2.5.11, 2.5.12, 2.5.13, 2.5.14, 2.6.0a1, 2.6.0a2, 2.6.0rc1, 2.6.0rc2, 2.6.0rc3, 2.6.0rc4, 2.6.0rc5, 2.6.0, 2.6.1, 2.6.2, 2.6.3, 2.6.4, 2.6.5, 2.6.6, 2.6.7, 2.6.8, 2.6.9, 2.6.10, 2.6.11, 2.7.0.dev0, 2.7.0a1, 2.7.0b1, 2.7.0rc1, 2.7.0rc2, 2.7.0rc3, 2.7.0rc4, 2.7.0, 2.7.1, 2.7.2, 2.7.3, 2.7.4, 2.7.5
```

The current original repo tag (2.7.5) must be deleted and added again in order to publish the Docker container with Ansible v2.7.5.